### PR TITLE
Add support for EDITOR usage for card creation

### DIFF
--- a/cmd/card_create.go
+++ b/cmd/card_create.go
@@ -75,7 +75,7 @@ var cardCreateCmd = &cobra.Command{
 			},
 			{
 				Name:   "description",
-				Prompt: &survey.Multiline{Message: "Description?"},
+				Prompt: &survey.Editor{Message: "Description?", FileName: "*.md"},
 			},
 			{
 				Name: "labels",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2022 Daniils Petrovs <daniils@platogo.com>
-
 */
 package cmd
 
@@ -14,7 +13,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "0.2.2"
+const Version = "0.3.0"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Fixes #21

Now when using `zube card create`, you can edit the card body using your default editor.